### PR TITLE
add Heroku deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,7 @@ Teespring made a Slack bot, because we're all about automation. You too can run 
 
 Setup
 -----
-1. Clone the repo with `git clone git@github.com:teespring/caviar-slack-bot.git` and `cd caviar-slack-bot`.
-1. Make an account on [Heroku](Heroku) and install the Heroku Toolbelt command line tools by going [here](http://toolbelt.heroku.com).
-1. Create a new Heroku app: `heroku create [YOUR_DESIRED_APP_NAME]`.
-1. Push the Caviar Slack bot to your new heroku app: `git push heroku master`.
+1. [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 1. Get an account with [Twilio](http://www.twilio.com). You'll probably want to add money to the account so that the voice messaging system feature works properly.
 1. Get a Twilio phone number. Doesn't matter what it is. Write this number down.
 1. Manage this number in the Twilio web UI. Add two HTTP POST webhooks, one for voice, one for SMS:

--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+  "name": "Caviar Slack Bot",
+  "description": "Solves real-world San Francisco startup problems",
+  "repository": "https://github.com/teespring/caviar-slack-bot",
+  "logo": "http://img1.wikia.nocookie.net/__cb20100324041931/disney/images/9/99/FatCat.jpg",
+  "keywords": ["ruby", "sinatra", "caviar", "twilio", "slack"]
+}


### PR DESCRIPTION
replaces manual Heroku steps with a simpler click-button deploy
