### PR TITLE
Use <!channel> so channel is notified

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -18,7 +18,7 @@ class Server < Sinatra::Application
 
   def alert_slack(text)
     uri = URI(slack_url)
-    message = "@here #{text}"
+    message = "<!channel> #{text}"
     icon_url = "#{base_url}/logo.jpg"
 
     https = Net::HTTP.new(uri.host, uri.port)


### PR DESCRIPTION
Using <!channel> instead of @here will cause the message to include a notification, which should help with watching for Caviar updates.

Reference is Slack's standard message markup page here: https://api.slack.com/docs/formatting
